### PR TITLE
Feat posts functionality

### DIFF
--- a/graphql/resolvers/index.js
+++ b/graphql/resolvers/index.js
@@ -7,6 +7,7 @@ module.exports = {
     ...usersResolvers.Query,
   },
   Mutation: {
-    ...usersResolvers.Mutation
+    ...usersResolvers.Mutation,
+    ...postsResolvers.Mutation,
   }
 }

--- a/graphql/resolvers/posts.js
+++ b/graphql/resolvers/posts.js
@@ -28,7 +28,6 @@ module.exports = {
   Mutation: {
     async createPost(_, { body }, context) {
       const user = checkAuth(context);
-      console.log(user);
 
       const newPost = new Post({
         body,

--- a/graphql/resolvers/posts.js
+++ b/graphql/resolvers/posts.js
@@ -1,14 +1,44 @@
 const Post = require('../../models/Post');
+const checkAuth = require('../../utils/check_auth')
 
 module.exports = {
   Query: {
-    async getPosts () {
+    async getPosts() {
       try {
-        const allPosts = await Post.find();
+        const allPosts = await Post.find().sort({ createdAt: -1 });
         return allPosts;
       } catch (error) {
         throw new Error(error);
       }
     },
+    async getPost(_, { postId }) {
+      try {
+        const post = await Post.findById(postId);
+        if (!post) {
+          throw new Error('Post not found.')
+        }
+
+        return post;
+      } catch (error) {
+        throw new Error(error);
+      }
+    }
+  },
+  Mutation: {
+    async createPost(_, { body }, context) {
+      const user = checkAuth(context);
+      console.log(user);
+
+      const newPost = new Post({
+        body,
+        user: user.id,
+        username: user.username,
+        createdAt: new Date().toISOString(),
+      });
+
+      const post = await newPost.save();
+
+      return post;
+    }
   }
 }

--- a/graphql/resolvers/posts.js
+++ b/graphql/resolvers/posts.js
@@ -1,5 +1,6 @@
 const Post = require('../../models/Post');
-const checkAuth = require('../../utils/check_auth')
+const checkAuth = require('../../utils/check_auth');
+const { AuthenticationError } = require('apollo-server');
 
 module.exports = {
   Query: {
@@ -39,6 +40,26 @@ module.exports = {
       const post = await newPost.save();
 
       return post;
+    },
+    async deletePost(_, { postId }, context) {
+      const user = checkAuth(context);
+
+      try {
+        const post = await Post.findById(postId);
+        if (!post) {
+          throw new AuthenticationError('Post not found!');
+        }
+
+        if (post.username === user.username) {
+          await post.delete();
+          return 'Post deleted successfully!';
+        } else {
+          throw new AuthenticationError('Action not allowed!');
+        }
+      } catch (error) {
+        throw new AuthenticationError(error);
+      }
+
     }
   }
 }

--- a/graphql/typeDefs.js
+++ b/graphql/typeDefs.js
@@ -26,10 +26,13 @@ module.exports = gql`
 
   type Query{
     getPosts: [Post]
+    getPost(postId: ID!): Post
   }
 
   type Mutation {
     register(userRegistrationDetails: UserRegistrationDetails) : User!
     login(username: String!, password: String!) : User!
+    createPost(body: String!): Post!
+    deletePost(postId: ID!): String!
   }
 `;

--- a/graphql/typeDefs.js
+++ b/graphql/typeDefs.js
@@ -30,8 +30,8 @@ module.exports = gql`
   }
 
   type Mutation {
-    register(userRegistrationDetails: UserRegistrationDetails) : User!
-    login(username: String!, password: String!) : User!
+    register(userRegistrationDetails: UserRegistrationDetails): User!
+    login(username: String!, password: String!): User!
     createPost(body: String!): Post!
     deletePost(postId: ID!): String!
   }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ const { MONGODB } = require('./config');
 // Setup a new server
 const server = new ApolloServer({
   typeDefs,
-  resolvers
+  resolvers,
+  context: ({ req }) => ({ req }),
 });
 
 // Be sure to connect to DB before server starts

--- a/utils/check_auth.js
+++ b/utils/check_auth.js
@@ -1,0 +1,24 @@
+const jwt = require('jsonwebtoken');
+const { AuthenticationError } = require('apollo-server');
+const { SECRET_KEY } = require('../config');
+
+module.exports = (context) => {
+  // context = { ... headers }
+  const authHeader = context.req.headers.authorization;
+  if (authHeader) {
+    const token = authHeader.split('Bearer ')[1];
+
+    if (!token) {
+      throw new AuthenticationError('Invalid/Expired token.');
+    }
+
+    try {
+      // authHeader = [Bearer token]
+      const user = jwt.verify(token, SECRET_KEY);
+      return user;
+    } catch (error) {
+      throw new AuthenticationError('Authentication token must be \'Bearer [token].');
+    }
+  }
+  throw new AuthenticationError('Authorization header must be provided.');
+}

--- a/utils/check_auth.js
+++ b/utils/check_auth.js
@@ -15,6 +15,10 @@ module.exports = (context) => {
     try {
       // authHeader = [Bearer token]
       const user = jwt.verify(token, SECRET_KEY);
+      if (!user) {
+        throw new AuthenticationError('You must be logged in.');
+      }
+
       return user;
     } catch (error) {
       throw new AuthenticationError('Authentication token must be \'Bearer [token].');


### PR DESCRIPTION
Added logic for the following functionality: 

- to get a post, 
- create a post by a logged in user and 
- delete a post
- ensure a user is not able to delete another user's post

This can be tested by running the following commands on the Graphql playground on [localhost:8005](http://localhost:63653/):

```
mutation createPost {
  createPost(body: "This is yet another new post from Uthman") {
    id
    body
    username
    createdAt
  }
}

mutation deletePost {
  deletePost(postId: "5df8d0c6fd09dd1575530c3e")
}
```
A header will be required and this can be gotten by first getting all posts using:
```
query {
  getPosts {
    id
    body
    username
    createdAt
  }
}
```
from which you can get a user's username say: *bondz* using password _12345_ to login to get the needed token to be passed as part of the header. Here's the command to login: 
```
mutation {
  login(username: "Uthman", password: "123456") {
    id
    username
    email
    token
    createdAt
  }
}
```

and then pass this the generated token as below:

```
{
  "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjVkZjNhODg2OWVkZWM2NjM2YTk0YTZjNiIsInVzZXJuYW1lIjoiVXRobWFuIiwiZW1haWwiOiJ1dGhtYW4uYWtpbmJpeWlAZGVjYWdvbi5kZXYiLCJpYXQiOjE1NzY1ODczNTUsImV4cCI6MTU3NjU5MDk1NX0.xnlywCHS6j2MeRnEnGhRSq92paY_Gi6u1fei6Jl8cB4"
}
```
Following these steps, a logged in user should be able to create a post and delete their own posts.